### PR TITLE
Alteração do width do btn-entrar

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -126,6 +126,7 @@ form{
 #btn-enviar{
     padding: 15px 60px;
     border-radius: 15px;
+    width: 80%;
     border: none;
     font-family: 'Dosis', sans-serif;
     font-weight: 600;
@@ -139,7 +140,6 @@ form{
     cursor: pointer;
     color: #fcfcfc;
     background-color: #333333;
-    padding: 15px 80px;
     
 }
 


### PR DESCRIPTION
Alterado o width do btn-entrar, pois  estava menor do que os inputs então, foi ajustado para melhorar o layout da página.

Feita a alteração retirei a predefinição de   padding: 15px 80px;.